### PR TITLE
Fixed navbar breaking in smaller screens

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,5 +1,5 @@
 import React from "react";
-import {Box, Flex, Heading,Link} from "@chakra-ui/react";
+import {Box, Flex, Heading,Link, Show} from "@chakra-ui/react";
 import Timer from "./Stopwatch/timer";
 import TabPanel from "./Tabs";
 import { Image } from "@chakra-ui/react";
@@ -7,7 +7,7 @@ export default function Navbar() {
   return (
     <>
     <Box pos="fixed" zIndex={10} w="100%" bg={"gray.100"} px={10} borderTopWidth="6px" borderColor='teal'>
-        <Flex h={20} alignItems={"center"} justifyContent={"space-between"}>
+        <Flex h={20} alignItems={"center"} justifyContent={"space-around"}>
           <Box>
             <Heading>
               <Link href="https://focusly.vercel.app/">
@@ -16,12 +16,25 @@ export default function Navbar() {
             </Heading>
           </Box>
           <Flex alignItems={"center"}>
+
+          <Show breakpoint='(min-width: 500px)'>
             <TabPanel />
+</Show>
+         
+         
           </Flex>
           <Box>
             <Timer />
           </Box>
         </Flex>
+
+        <Show breakpoint='(max-width: 500px)'>
+        <Flex alignItems={"center"} justifyContent={"center"}>
+            <TabPanel />
+            </Flex>
+
+          </Show>
+         
       </Box>
     </>
   );

--- a/src/components/Stopwatch/timer.js
+++ b/src/components/Stopwatch/timer.js
@@ -3,6 +3,8 @@ import { formatTime } from '../utils';
 import {Box,Text} from "@chakra-ui/react";
 import { MyContext } from '../../context';
 
+
+
 const Timer = () => {
   const {timer}  = useContext(MyContext);
   
@@ -12,7 +14,7 @@ const Timer = () => {
         <Box fontSize='sm'>
           Focused Time
         </Box>
-        <Text  fontSize='xl' fontWeight="semibold">{formatTime(timer)}</Text>
+        <Text  fontSize={{ base: '15', sm: '22'}} fontWeight="semibold">{formatTime(timer)}</Text>
       </Box>
     </div>
   );

--- a/src/components/Stopwatch/timer.js
+++ b/src/components/Stopwatch/timer.js
@@ -12,7 +12,7 @@ const Timer = () => {
         <Box fontSize='sm'>
           Focused Time
         </Box>
-        <Text  fontSize={{ base: '15', sm: '22'}} fontWeight="semibold">{formatTime(timer)}</Text>
+        <Text  fontSize="17" fontWeight="semibold">{formatTime(timer)}</Text>
       </Box>
     </div>
   );

--- a/src/components/Stopwatch/timer.js
+++ b/src/components/Stopwatch/timer.js
@@ -3,8 +3,6 @@ import { formatTime } from '../utils';
 import {Box,Text} from "@chakra-ui/react";
 import { MyContext } from '../../context';
 
-
-
 const Timer = () => {
   const {timer}  = useContext(MyContext);
   


### PR DESCRIPTION
## Related Issue#71

I have fixed the navbar breaking(timer overflow) in smaller screens by adding responsive size to timer font.
[Screencast from 23-04-23 06:43:19 PM IST.webm](https://user-images.githubusercontent.com/37241695/233841968-9f7efc4e-a57e-4eee-bedf-4d243556cdb9.webm)
