### PR TITLE
Fix for multiple Lo-fi and meditate songs playing at once

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -76,7 +76,7 @@ const Card = (props, initialState = 0) => {
   const handlePlay = () => {
     setSoundStatus({ ...soundStatus, playing: !playing });
     !isActive && !isPaused ? handleStart() : handlePause();
-    props.setCurrentSong(props.sound);                    //set the current song to the song being clicked
+    props.setCurrentAudio(props.sound);                    //set the current song to the song being clicked
   };
 
   const handlePauseCard = () => {
@@ -86,11 +86,11 @@ const Card = (props, initialState = 0) => {
 
   //this block checks if the current song is the same as the song in the card
   useEffect(() => {
-    if(props.currentSong !== props.sound && playing && props.multi===false){  //if not then toggle the status
+    if(props.currentAudio !== props.sound && playing && props.multi===false){  //if not then toggle the status
       setSoundStatus({ ...soundStatus, playing: !playing });
     !isActive && !isPaused ? handleStart() : handlePause();
     }
-  }, [props.currentSong]);
+  }, [props.currentAudio]);
 
 
   if (!playing) {

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -76,7 +76,7 @@ const Card = (props, initialState = 0) => {
   const handlePlay = () => {
     setSoundStatus({ ...soundStatus, playing: !playing });
     !isActive && !isPaused ? handleStart() : handlePause();
-    props.setCurrentSong(props.sound);
+    props.setCurrentSong(props.sound);                    //set the current song to the song being clicked
   };
 
   const handlePauseCard = () => {
@@ -84,9 +84,9 @@ const Card = (props, initialState = 0) => {
     isPaused ? handlePause() : handleResume();
   };
 
-
+  //this block checks if the current song is the same as the song in the card
   useEffect(() => {
-    if(props.currentSong !== props.sound && playing && props.multi===false){
+    if(props.currentSong !== props.sound && playing && props.multi===false){  //if not then toggle the status
       setSoundStatus({ ...soundStatus, playing: !playing });
     !isActive && !isPaused ? handleStart() : handlePause();
     }

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,4 +1,4 @@
-import React, { Suspense, useState, useContext, useRef } from "react";
+import React, { Suspense, useState, useContext, useRef,useEffect } from "react";
 import {
   BsFillPlayFill,
   BsPauseFill,
@@ -76,12 +76,22 @@ const Card = (props, initialState = 0) => {
   const handlePlay = () => {
     setSoundStatus({ ...soundStatus, playing: !playing });
     !isActive && !isPaused ? handleStart() : handlePause();
+    props.setCurrentSong(props.sound);
   };
 
   const handlePauseCard = () => {
     setSoundStatus({ ...soundStatus, playing: true, paused: !paused });
     isPaused ? handlePause() : handleResume();
   };
+
+
+  useEffect(() => {
+    if(props.currentSong !== props.sound && playing && props.multi===false){
+      setSoundStatus({ ...soundStatus, playing: !playing });
+    !isActive && !isPaused ? handleStart() : handlePause();
+    }
+  }, [props.currentSong]);
+
 
   if (!playing) {
     return (

--- a/src/components/Lofi.js
+++ b/src/components/Lofi.js
@@ -3,7 +3,7 @@ import { Box, Center, SimpleGrid } from "@chakra-ui/react";
 import Card from "./Card";
 
 export default function Lofi() {
-  const [currentSong, setCurrentSong] = useState(null);
+  const [currentSong, setCurrentSong] = useState(null);       //tracks the current song
   const [info, setinfo] = useState([
     {
       id: "1",

--- a/src/components/Lofi.js
+++ b/src/components/Lofi.js
@@ -3,7 +3,7 @@ import { Box, Center, SimpleGrid } from "@chakra-ui/react";
 import Card from "./Card";
 
 export default function Lofi() {
-  const [currentSong, setCurrentSong] = useState(null);       //tracks the current song
+  const [currentAudio, setCurrentAudio] = useState(null);       //tracks the current song
   const [info, setinfo] = useState([
     {
       id: "1",
@@ -71,7 +71,7 @@ export default function Lofi() {
     <Box maxW={"100%"}>
       <Center>
         <SimpleGrid columns={[1, 2, 3]}>
-          {info && info.map((post) => <Card key={post.id} {...post} currentSong={currentSong} setCurrentSong={setCurrentSong} multi={false}/>)}
+          {info && info.map((post) => <Card key={post.id} {...post} currentAudio={currentAudio} setCurrentAudio={setCurrentAudio} multi={false}/>)}
         </SimpleGrid>
       </Center>
     </Box>

--- a/src/components/Lofi.js
+++ b/src/components/Lofi.js
@@ -3,6 +3,7 @@ import { Box, Center, SimpleGrid } from "@chakra-ui/react";
 import Card from "./Card";
 
 export default function Lofi() {
+  const [currentSong, setCurrentSong] = useState(null);
   const [info, setinfo] = useState([
     {
       id: "1",
@@ -70,7 +71,7 @@ export default function Lofi() {
     <Box maxW={"100%"}>
       <Center>
         <SimpleGrid columns={[1, 2, 3]}>
-          {info && info.map((post) => <Card key={post.id} {...post} />)}
+          {info && info.map((post) => <Card key={post.id} {...post} currentSong={currentSong} setCurrentSong={setCurrentSong} multi={false}/>)}
         </SimpleGrid>
       </Center>
     </Box>

--- a/src/components/Meditate.js
+++ b/src/components/Meditate.js
@@ -1,8 +1,10 @@
-import React, {useState} from "react";
+import React, {useState,useEffect} from "react";
 import {Box, Center,Heading, SimpleGrid} from "@chakra-ui/react";
 import Card from "./Card";
 
 function Meditate() {
+
+  const [currentSong, setCurrentSong] = useState(null);
   const [newinfo,setnewInfo] = useState([
     {
       id: "1",
@@ -50,7 +52,7 @@ function Meditate() {
         <Heading mb={1}>New</Heading>  
           <Center>
           <SimpleGrid columns={[1, 2, 4]}>
-            {newinfo && newinfo.map((post) => <Card key={post.id} {...post} />)}
+            {newinfo && newinfo.map((post) => <Card key={post.id} {...post} currentSong={currentSong} setCurrentSong={setCurrentSong} multi={false}/>)}
           </SimpleGrid>
           </Center>
         </Box>
@@ -59,7 +61,7 @@ function Meditate() {
 
         <Center>
           <SimpleGrid columns={[1, 2, 4]}>
-            {info && info.map((post) => <Card key={post.id} {...post} />)}
+            {info && info.map((post) => <Card key={post.id} {...post} currentSong={currentSong} setCurrentSong={setCurrentSong} multi={false}/>)}
           </SimpleGrid>
         </Center>
         </Box>

--- a/src/components/Meditate.js
+++ b/src/components/Meditate.js
@@ -4,7 +4,7 @@ import Card from "./Card";
 
 function Meditate() {
 
-  const [currentSong, setCurrentSong] = useState(null);             //tracks the current song
+  const [currentAudio, setCurrentAudio] = useState(null);             //tracks the current song
   const [newinfo,setnewInfo] = useState([
     {
       id: "1",
@@ -52,7 +52,7 @@ function Meditate() {
         <Heading mb={1}>New</Heading>  
           <Center>
           <SimpleGrid columns={[1, 2, 4]}>
-            {newinfo && newinfo.map((post) => <Card key={post.id} {...post} currentSong={currentSong} setCurrentSong={setCurrentSong} multi={false}/>)}
+            {newinfo && newinfo.map((post) => <Card key={post.id} {...post} currentAudio={currentAudio} setCurrentAudio={setCurrentAudio} multi={false}/>)}
           </SimpleGrid>
           </Center>
         </Box>
@@ -61,7 +61,7 @@ function Meditate() {
 
         <Center>
           <SimpleGrid columns={[1, 2, 4]}>
-            {info && info.map((post) => <Card key={post.id} {...post} currentSong={currentSong} setCurrentSong={setCurrentSong} multi={false}/>)}
+            {info && info.map((post) => <Card key={post.id} {...post} currentAudio={currentAudio} setCurrentAudio={setCurrentAudio} multi={false}/>)}
           </SimpleGrid>
         </Center>
         </Box>

--- a/src/components/Meditate.js
+++ b/src/components/Meditate.js
@@ -4,7 +4,7 @@ import Card from "./Card";
 
 function Meditate() {
 
-  const [currentSong, setCurrentSong] = useState(null);
+  const [currentSong, setCurrentSong] = useState(null);             //tracks the current song
   const [newinfo,setnewInfo] = useState([
     {
       id: "1",


### PR DESCRIPTION
## Related Issue 

Closes: #122
Makes only one song play at a time under Lo-Fi and Meditate tabs

### Describe the changes you've made

I added some props to the card component which keeps track of the current song playing and also checks if multiple songs needs to be played.
I added a useEffect hook to toggle playing state of previously playing song cards depending on the current Song tracker state 
( Provided the multi prop is set to false)

## Type of change

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran npm server and tested it on chrome and edge browsers

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.

## Screenshots

