### PR TITLE
fixed shuffle button overlap with footer

### DIFF
--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -91,9 +91,10 @@ function Homepage() {
         </Box>
       </Container>
       <Box
-        position="fixed"
-        bottom={4}
-        right={14}
+        position="sticky"
+        bottom={8}
+        marginRight={[4,6,8]}
+        marginBottom={[2,4]}
         display="flex"
         justifyContent="flex-end"
       >


### PR DESCRIPTION
## Related Issue 

Closes: #128 

### Describe the changes you've made

Shuffle button overlapped in footer has been changed now shuffle not visible in footer

## Type of change

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested in various screen sizes by manually

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

| Original | Updated |
| --- | --- |
| ![Original](https://github.com/Utkarshn10/Focusly/assets/93966956/7f5843ed-8de8-4bb6-89c5-df164b17263e) | ![Updated](https://github.com/Utkarshn10/Focusly/assets/93966956/329341db-bd4f-4c02-8ff9-4d3bf47b12ee) |
