### PR TITLE
fix typo in github logo image path

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -56,7 +56,7 @@ const Footer = () => {
             </Link>
             <Link href="https://github.com/Utkarshn10/Focusly">
               <Image
-                src="../GitHub_logo-bg-removed.png"
+                src="../Github_logo-bg-removed.png"
                 boxSize={isMobile ? "40px" : "40px"}
                 maxW={isMobile ? "70px" : "70px"}
                 borderRadius="full"


### PR DESCRIPTION
## Related Issue 

Closes: #139 number that will be closed through this PR

### Describe the changes you've made

Github logo was not visible in the footer due to typo in the src path. The filename spells "GitHub" as "Github"
`src="../GitHub_logo-bg-removed.png"` is now changed to `src="../Github_logo-bg-removed.png"` 

## Type of change

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Verified that the logo is visible in my localhost itself since its a small change.

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
|![focusly_logo_absent](https://github.com/Utkarshn10/Focusly/assets/26301834/b47e5011-5954-41da-aa43-d1eaba0e93f7)|![image_2023-11-02_201532549 (1)](https://github.com/Utkarshn10/Focusly/assets/26301834/1df49621-419e-4c8d-819f-1871865b63ba)|





